### PR TITLE
extract raw query parameters to fix clickthrough url truncation issue

### DIFF
--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
@@ -434,7 +434,7 @@ class FullScreenMessage extends CampaignMessage {
             }
 
             // extract query, eg: id=h11901a,86f10d,3&url=https://www.adobe.com
-            final String query = uri.getQuery();
+            final String query = uri.getRawQuery();
 
             // Populate message data
             final Map<String, String> messageData = Utils.extractQueryParameters(query);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- extract raw query parameters from the clickthrough url to preserve any customer provided url encoded query parameters.
- docs to be updated stating that a clickthrough url containing query parameters must be url encoded.

## Related Issue
MOB-18446
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
