### PR TITLE
fix message frequency rules

### DIFF
--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignExtension.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignExtension.java
@@ -273,6 +273,7 @@ public class CampaignExtension extends Extension {
             eventData.put(CampaignConstants.EventDataKeys.RuleEngine.CONSEQUENCE_TRIGGERED, triggeredConsequence);
             final Event rulesResponseEvent = new Event.Builder(CAMPAIGN_RULES_RESPONSE_EVENT, EventType.RULES_ENGINE, EventSource.RESPONSE_CONTENT).setEventData(eventData).build();
             extensionApi.dispatch(rulesResponseEvent);
+            return;
         }
 
         try {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- the rules engine is not dispatching rules response events when an event matches a rule. this was causing the user profile based frequency rules to not be matched. to resolve it, a rules response event is dispatched by the campaign extension for the profile extension to process.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
