### PR TITLE
use bundled assets if remote assets failed to be cached

### DIFF
--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java
@@ -40,6 +40,7 @@ final class CampaignConstants {
     static final String CACHE_BASE_DIR = "campaign";
     static final String MESSAGE_CACHE_DIR = "messages";
     static final String ZIP_HANDLE = "campaign_rules.zip";
+    static final String LOCAL_ASSET_URI = "file:///android_asset/";
 
     static final String MESSAGE_SCHEME = "adbinapp";
     static final String MESSAGE_SCHEME_PATH_CANCEL = "cancel";

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
@@ -271,16 +271,14 @@ class FullScreenMessage extends CampaignMessage {
 
                 if (isLocalImage) {
                     try {
-                        final String cacheName = CampaignConstants.CACHE_BASE_DIR + File.separator + CampaignConstants.MESSAGE_CACHE_DIR;
-                        final String assetCacheUrl = CampaignConstants.LOCAL_ASSET_URI + assetUrl;
+                        final String cacheName = MESSAGES_CACHE + messageId;
                         final InputStream bundledFile = ServiceProvider.getInstance().getAppContextService().getApplicationContext().getAssets().open(assetValue);
-                        cacheService.set(cacheName, assetCacheUrl, new CacheEntry(bundledFile, CacheExpiry.never(), null));
-                        fallbackImagesMap.put(assetCacheUrl, cacheName);
+                        cacheService.set(cacheName, assetUrl, new CacheEntry(bundledFile, CacheExpiry.never(), null));
+                        fallbackImagesMap.put(assetUrl, cacheName);
                         bundledFile.close();
                     } catch (final IOException exception) {
                         Log.debug(CampaignConstants.LOG_TAG, SELF_TAG,
                                 "createCachedResourcesMap - Exception occurred reading bundled asset: %s.", exception.getMessage());
-                        break;
                     }
 
                 }

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/FullScreenMessage.java
@@ -237,12 +237,6 @@ class FullScreenMessage extends CampaignMessage {
             return Collections.emptyMap();
         }
 
-        if (cacheService == null) {
-            Log.debug(CampaignConstants.LOG_TAG, SELF_TAG,
-                    "createCachedResourcesMap - No cache service found, cannot generate local resource mapping.");
-            return Collections.emptyMap();
-        }
-
         final Map<String, String> cachedImagesMap = new HashMap<>();
         final Map<String, String> fallbackImagesMap = new HashMap<>();
 
@@ -277,7 +271,7 @@ class FullScreenMessage extends CampaignMessage {
 
                 if (isLocalImage) {
                     try {
-                        final String cacheName = CampaignConstants.CACHE_BASE_DIR + File.separator + CampaignConstants.RULES_CACHE_FOLDER;
+                        final String cacheName = CampaignConstants.CACHE_BASE_DIR + File.separator + CampaignConstants.MESSAGE_CACHE_DIR;
                         final String assetCacheUrl = CampaignConstants.LOCAL_ASSET_URI + assetUrl;
                         final InputStream bundledFile = ServiceProvider.getInstance().getAppContextService().getApplicationContext().getAssets().open(assetValue);
                         cacheService.set(cacheName, assetCacheUrl, new CacheEntry(bundledFile, CacheExpiry.never(), null));

--- a/code/campaign/src/phone/java/com/adobe/marketing/mobile/Campaign.java
+++ b/code/campaign/src/phone/java/com/adobe/marketing/mobile/Campaign.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Campaign {
-	private final static String EXTENSION_VERSION = "2.0.4";
+	private final static String EXTENSION_VERSION = "2.0.5";
 	private static final String LOG_TAG = "Campaign";
 	private static final String LINKAGE_FIELDS = "linkagefields";
 

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignPublicAPITests.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignPublicAPITests.java
@@ -34,7 +34,7 @@ public class CampaignPublicAPITests {
 
     @Test
     public void test_extensionVersion() {
-        assertEquals("2.0.4", Campaign.extensionVersion());
+        assertEquals("2.0.5", Campaign.extensionVersion());
     }
 
     @Test

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/CampaignExtensionTests.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/CampaignExtensionTests.java
@@ -289,7 +289,7 @@ public class CampaignExtensionTests {
         String version = campaignExtension.getVersion();
 
         // verify
-        assertEquals("2.0.4", version);
+        assertEquals("2.0.5", version);
     }
 
     @Test

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/FullScreenMessageTests.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/FullScreenMessageTests.java
@@ -399,7 +399,7 @@ public class FullScreenMessageTests {
         setupServiceProviderMockAndRunTest(() -> {
             Mockito.when(mockCacheService.get(anyString(), eq("http://asset1-url00.jpeg"))).thenReturn(null);
             Map<String, String> expectedMap = new HashMap<>();
-            expectedMap.put("file:///android_asset/http://asset1-url00.jpeg", "campaign/messages");
+            expectedMap.put("http://asset1-url00.jpeg", "campaign/messages/07a1c997-2450-46f0-a454-537906404124");
             try {
                 FullScreenMessage fullScreenMessage = new FullScreenMessage(mockCampaignExtension,
                         TestUtils.createRuleConsequence(happyMessageMap));

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -14,7 +14,7 @@ android.enableJetifier=true
 moduleProjectName=campaign
 moduleName=campaign
 moduleAARName=campaign-phone-release.aar
-moduleVersion=2.0.4
+moduleVersion=2.0.5
 
 mavenRepoName=AdobeMobileCampaignSdk
 mavenRepoDescription=Adobe Experience Platform Campaign extension for the Adobe Experience Platform Mobile SDK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The remote assets not being cached means that the remote url failed to be connected to. in this scenario use the bundled asset as a fallback.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
