### PR TITLE
Handle no internet + Move LocalNotification receivers to com.adobe.marketing.mobile package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ assemble-phone-release:
 assemble-app:
 	(./code/gradlew -p code/$(TEST-APP-FOLDER-NAME)  assemble)
 
-ci-publish-maven-local-jitpack: assemblePhoneRelease
+ci-publish-maven-local-jitpack: assemble-phone-release
 	(./code/gradlew -p code/$(EXTENSION-LIBRARY-FOLDER-NAME) publishReleasePublicationToMavenLocal -Pjitpack  -x signReleasePublication)
 
-ci-publish-staging: assemblePhoneRelease
+ci-publish-staging: assemble-phone-release
 	(./code/gradlew -p code/$(EXTENSION-LIBRARY-FOLDER-NAME) publishReleasePublicationToSonatypeRepository)
 
-ci-publish: assemblePhoneRelease
+ci-publish: assemble-phone-release
 	(./code/gradlew -p code/$(EXTENSION-LIBRARY-FOLDER-NAME) publishReleasePublicationToSonatypeRepository -Prelease)

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java
@@ -24,7 +24,6 @@ final class CampaignConstants {
 
     static final String LOG_TAG = "Campaign";
     static final String EXTENSION_NAME = "com.adobe.module.campaign";
-    static final String EXTENSION_VERSION = "3.0.0";
     static final String RULE_ENGINE_NAME = EXTENSION_NAME + ".rulesengine";
     static final String FRIENDLY_NAME = "Campaign";
     static final String DEPRECATED_1X_HIT_DATABASE_FILENAME = "ADBMobileCampaign.sqlite";

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignExtension.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignExtension.java
@@ -16,6 +16,7 @@ import android.content.SharedPreferences;
 import android.util.Base64;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import com.adobe.marketing.mobile.Campaign;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
@@ -179,7 +180,7 @@ public class CampaignExtension extends Extension {
 
     @Override
     protected String getVersion() {
-        return CampaignConstants.EXTENSION_VERSION;
+        return Campaign.extensionVersion();
     }
 
     @Override

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignMessageAssetsDownloader.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignMessageAssetsDownloader.java
@@ -99,8 +99,8 @@ class CampaignMessageAssetsDownloader {
                             Log.warning(
                                     CampaignConstants.LOG_TAG,
                                     SELF_TAG,
-                                    "downloadAssetCollection - Internet not available. Failed to download asset from URL:"
-                                            + " %s",
+                                    "downloadAssetCollection - Internet not available. Failed to"
+                                            + " download asset from URL: %s",
                                     url);
                             return;
                         }

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignMessageAssetsDownloader.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignMessageAssetsDownloader.java
@@ -95,6 +95,15 @@ class CampaignMessageAssetsDownloader {
             networkService.connectAsync(
                     networkRequest,
                     connection -> {
+                        if (connection == null) {
+                            Log.warning(
+                                    CampaignConstants.LOG_TAG,
+                                    SELF_TAG,
+                                    "downloadAssetCollection - Internet not available. Failed to download asset from URL:"
+                                            + " %s",
+                                    url);
+                            return;
+                        }
                         if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
                             Log.debug(
                                     CampaignConstants.LOG_TAG,

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignRulesDownloader.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignRulesDownloader.java
@@ -127,7 +127,8 @@ class CampaignRulesDownloader {
                         Log.warning(
                                 CampaignConstants.LOG_TAG,
                                 SELF_TAG,
-                                "loadRulesFromUrl - No internet connection. Unable to download rules.",
+                                "loadRulesFromUrl - No internet connection. Unable to download"
+                                        + " rules.",
                                 url);
                         return;
                     }

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignRulesDownloader.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignRulesDownloader.java
@@ -123,6 +123,14 @@ class CampaignRulesDownloader {
         networkService.connectAsync(
                 networkRequest,
                 httpConnecting -> {
+                    if (httpConnecting == null) {
+                        Log.warning(
+                                CampaignConstants.LOG_TAG,
+                                SELF_TAG,
+                                "loadRulesFromUrl - No internet connection. Unable to download rules.",
+                                url);
+                        return;
+                    }
                     onRulesDownloaded(url, httpConnecting);
                 });
     }

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/LocalNotificationService.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/LocalNotificationService.java
@@ -16,7 +16,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-
 import com.adobe.marketing.mobile.LocalNotificationHandler;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.MapUtils;

--- a/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/LocalNotificationService.java
+++ b/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/LocalNotificationService.java
@@ -16,6 +16,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+
+import com.adobe.marketing.mobile.LocalNotificationHandler;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.MapUtils;
 import java.security.SecureRandom;

--- a/code/campaign/src/phone/java/com/adobe/marketing/mobile/LocalNotificationHandler.java
+++ b/code/campaign/src/phone/java/com/adobe/marketing/mobile/LocalNotificationHandler.java
@@ -9,7 +9,7 @@
   governing permissions and limitations under the License.
 */
 
-package com.adobe.marketing.mobile.campaign;
+package com.adobe.marketing.mobile;
 
 import android.app.Activity;
 import android.app.Notification;
@@ -31,7 +31,6 @@ import android.os.Build;
 import android.os.Bundle;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
-import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.DeviceInforming;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceProvider;
@@ -40,7 +39,7 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 
 @SuppressWarnings("unchecked")
-class LocalNotificationHandler extends BroadcastReceiver {
+public class LocalNotificationHandler extends BroadcastReceiver {
 
     private static final String LOG_TAG = "Campaign";
     private static final String SELF_TAG = "LocalNotificationHandler";

--- a/code/campaign/src/phone/java/com/adobe/marketing/mobile/NotificationDismissalHandler.java
+++ b/code/campaign/src/phone/java/com/adobe/marketing/mobile/NotificationDismissalHandler.java
@@ -9,12 +9,11 @@
   governing permissions and limitations under the License.
 */
 
-package com.adobe.marketing.mobile.campaign;
+package com.adobe.marketing.mobile;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.Log;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,20 +22,21 @@ import java.util.Map;
  * A {@link BroadcastReceiver} that triggers when user dismisses local notification from
  * notification panel. It does the click tracking for local notification.
  */
-final class NotificationDismissalHandler extends BroadcastReceiver {
+public final class NotificationDismissalHandler extends BroadcastReceiver {
     private static final String SELF_TAG = "NotificationDismissalHandler";
     private static final String KEY_BROADLOG_ID = "broadlogId";
     private static final String KEY_DELIVERY_ID = "deliveryId";
     private static final String KEY_ACTION = "action";
     private static final String NOTIFICATION_USER_INFO_KEY = "NOTIFICATION_USER_INFO";
     private static final int MESSAGE_INFO_MAP_SIZE = 3;
+    private static final String LOG_TAG = "Campaign";
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
         if (!intent.hasExtra(NOTIFICATION_USER_INFO_KEY)) {
             return;
         }
-        Log.debug(CampaignConstants.LOG_TAG, SELF_TAG, "Notification dismissed");
+        Log.debug(LOG_TAG, SELF_TAG, "Notification dismissed");
         final Map<String, Object> notificationData =
                 (Map<String, Object>) intent.getSerializableExtra(NOTIFICATION_USER_INFO_KEY);
 

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignPublicAPITests.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignPublicAPITests.java
@@ -30,7 +30,7 @@ public class CampaignPublicAPITests {
 
     @Test
     public void test_extensionVersion() {
-        assertEquals("3.0.0", Campaign.extensionVersion());
+        assertEquals(CampaignTestConstants.EXTENSION_VERSION, Campaign.extensionVersion());
     }
 
     @Test

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignTestConstants.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignTestConstants.java
@@ -1,0 +1,16 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+public class CampaignTestConstants {
+    public static final String EXTENSION_VERSION = "3.0.0";
+}

--- a/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/CampaignExtensionTests.java
+++ b/code/campaign/src/test/java/com/adobe/marketing/mobile/campaign/CampaignExtensionTests.java
@@ -31,6 +31,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Base64;
+import com.adobe.marketing.mobile.CampaignTestConstants;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
@@ -315,7 +316,7 @@ public class CampaignExtensionTests {
         String version = campaignExtension.getVersion();
 
         // verify
-        assertEquals("3.0.0", version);
+        assertEquals(CampaignTestConstants.EXTENSION_VERSION, version);
     }
 
     @Test

--- a/code/testapps/kotlin_test_app/src/main/AndroidManifest.xml
+++ b/code/testapps/kotlin_test_app/src/main/AndroidManifest.xml
@@ -63,12 +63,8 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
-
-        <activity android:name="com.adobe.marketing.mobile.FullscreenMessageActivity" />
-
         <receiver android:name="com.adobe.marketing.mobile.LocalNotificationHandler" />
 
-        <activity android:name="com.adobe.griffon.FullScreenTakeoverActivity" />
     </application>
 
 </manifest>

--- a/code/testapps/testapp/src/main/AndroidManifest.xml
+++ b/code/testapps/testapp/src/main/AndroidManifest.xml
@@ -55,14 +55,14 @@
         <activity android:name=".SignUpActivity"></activity>
         <activity android:name=".SettingsActivity"></activity>
 
-        <receiver android:name="com.adobe.marketing.mobile.campaign.LocalNotificationHandler"  android:exported="true">
+        <receiver android:name="com.adobe.marketing.mobile.LocalNotificationHandler"  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.INPUT_METHOD_CHANGED" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.adobe.marketing.mobile.campaign.NotificationDismissalHandler" />
+        <receiver android:name="com.adobe.marketing.mobile.NotificationDismissalHandler" />
 
         <service android:name=".CampaignFirebaseMessagingService"
             android:exported="true">

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -9,6 +9,7 @@ LINE="==========================================================================
 VERSION_REGEX="[0-9]+\.[0-9]+\.[0-9]+"
 
 GRADLE_PROPERTIES_FILE=$ROOT_DIR"/code/gradle.properties"
+TEST_CONSTANTS_FILE=$ROOT_DIR"/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignTestConstants.java"
 CONSTANTS_FILE=$ROOT_DIR"/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java"
 # Java files
 EXTENSION_VERSION_REGEX="^.*String EXTENSION_VERSION *= *"
@@ -41,6 +42,10 @@ update() {
     # Replace version in Constants file
     echo "Changing 'EXTENSION_VERSION' to '$VERSION' in '$CONSTANTS_FILE'"    
     sed_platform -E "/$EXTENSION_VERSION_REGEX/{s/$VERSION_REGEX/$VERSION/;}" $CONSTANTS_FILE
+
+    # Replace version in Test Constants file
+    echo "Changing 'EXTENSION_VERSION' to '$VERSION' in '$TEST_CONSTANTS_FILE'"    
+    sed_platform -E "/$EXTENSION_VERSION_REGEX/{s/$VERSION_REGEX/$VERSION/;}" $TEST_CONSTANTS_FILE
 
     # Replace version in gradle.properties
     echo "Changing 'moduleVersion' to '$VERSION' in '$GRADLE_PROPERTIES_FILE'"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -10,7 +10,7 @@ VERSION_REGEX="[0-9]+\.[0-9]+\.[0-9]+"
 
 GRADLE_PROPERTIES_FILE=$ROOT_DIR"/code/gradle.properties"
 TEST_CONSTANTS_FILE=$ROOT_DIR"/code/campaign/src/test/java/com/adobe/marketing/mobile/CampaignTestConstants.java"
-CONSTANTS_FILE=$ROOT_DIR"/code/campaign/src/main/java/com/adobe/marketing/mobile/campaign/CampaignConstants.java"
+CONSTANTS_FILE=$ROOT_DIR"/code/campaign/src/phone/java/com/adobe/marketing/mobile/Campaign.java"
 # Java files
 EXTENSION_VERSION_REGEX="^.*String EXTENSION_VERSION *= *"
 # Kotlin files


### PR DESCRIPTION
This PR contains the following changes:
- Handle gracefully when the network connection is null due to no internet.
- Make LocalNotification broadcast receivers public
- move LocalNotification broadcast receivers from `com.adobe.marketing.mobile.campaign` to  `com.adobe.marketing.mobile` package
- updateVersion script to update extension version in both source and test files 